### PR TITLE
パジネーションとフィルタリング

### DIFF
--- a/api/nexus-typegen.ts
+++ b/api/nexus-typegen.ts
@@ -161,7 +161,7 @@ export interface NexusGenFieldTypes {
     profile: NexusGenRootTypes['Profile'] | null; // Profile
     profiles: NexusGenRootTypes['Profile'][]; // [Profile!]!
     skills: NexusGenRootTypes['Skill'][]; // [Skill!]!
-    unmatchedPosts: Array<NexusGenRootTypes['Post'] | null>; // [Post]!
+    unmatchedPosts: NexusGenRootTypes['Post'][]; // [Post!]!
   }
   Skill: { // field return type
     id: number; // Int!
@@ -320,11 +320,21 @@ export interface NexusGenArgTypes {
     messagesByPostId: { // args
       postId: string; // String!
     }
+    myCommunities: { // args
+      skip?: number | null; // Int
+      take?: number | null; // Int
+    }
     post: { // args
       id: string; // String!
     }
     profile: { // args
       id: number; // Int!
+    }
+    unmatchedPosts: { // args
+      driverNameFilter?: string | null; // String
+      requiredSkillsFilter?: number | null; // Int
+      skip?: number | null; // Int
+      take?: number | null; // Int
     }
   }
   Subscription: {

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -67,7 +67,7 @@ type Query {
   communities: [Community!]!
   feed: [Post!]!
   messagesByPostId(postId: String!): [Message!]!
-  myCommunities: [Community!]!
+  myCommunities(skip: Int, take: Int): [Community!]!
   myCurrentCommunity: Community
   myDrivingPosts: [Post!]!
   myMatchedPosts: [Post!]!
@@ -76,7 +76,7 @@ type Query {
   profile(id: Int!): Profile
   profiles: [Profile!]!
   skills: [Skill!]!
-  unmatchedPosts: [Post]!
+  unmatchedPosts(driverNameFilter: String, requiredSkillsFilter: Int, skip: Int, take: Int): [Post!]!
 }
 
 type Skill {

--- a/api/src/graphql/Community.ts
+++ b/api/src/graphql/Community.ts
@@ -34,8 +34,13 @@ export const CommunityQuery = extendType({
     // List communities that user has
     t.nonNull.list.nonNull.field("myCommunities", {
       type: "Community",
+      args: {
+        skip: intArg(),
+        take: intArg(),
+      },
       async resolve(parent, args, context) {
         const { userId } = context;
+        const { skip, take } = args;
         if (!userId) {
           throw new Error("You have to log in");
         }
@@ -43,6 +48,8 @@ export const CommunityQuery = extendType({
         const profiles = await context.prisma.profile.findMany({
           where: { userId },
           include: { community: true },
+          skip: skip as number | undefined,
+          take: take as number | undefined,
         });
 
         return profiles.map((profile) => profile.community);


### PR DESCRIPTION
closes https://github.com/42supporters-hackason/P2P-matching/issues/99

`unmatchedPosts`の `requiredSkills`のフィルタリングが悩みどころ。とりあえず一つのIDだけ指定できるようにしたけど、複数できた方がいいと思う。prismaレベルで複数やる方法が分からなかった。

## 参考URL
- [GraphQL Filtering, Pagination & Sorting Tutorial with TypeScript](https://www.howtographql.com/typescript-apollo/8-filtering-pagination-and-sorting/)
- [Filtering and sorting (Concepts) | Prisma Docs](https://www.prisma.io/docs/concepts/components/prisma-client/filtering-and-sorting)

## テストのスクショ

![Screen Shot 2022-08-14 at 21 12 44](https://user-images.githubusercontent.com/69781798/184536267-a4cce6bd-90fc-4bd9-b86d-bc3e98b6ed95.png)

![Screen Shot 2022-08-14 at 21 11 22](https://user-images.githubusercontent.com/69781798/184536229-65c0443f-0d51-4ebd-ab4f-b440e94778b5.png)



![Screen Shot 2022-08-14 at 21 10 35](https://user-images.githubusercontent.com/69781798/184536202-74662458-b6bd-4391-bb3c-6edd1c611ac4.png)
